### PR TITLE
Update jquery-price-format dependency

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -59,7 +59,7 @@
     "jquery-hashchange": "https://github.com/gseguin/jquery-hashchange.git",
     "jquery-maskedinput": "1.3.1",
     "jquery-mobile-bower": "1.4.2",
-    "jquery-price-format": "2.0.0",
+    "jquery-price-format": "2.0",
     "jquery-ui": "1.11.2",
     "jqueryui-timepicker-addon": "1.5.0",
     "js-beautify": "1.5.4",


### PR DESCRIPTION
`bower jquery-price-format#2.0.0                     ENORESTARGET No tag found that was able to satisfy 2.0.0`

Repository maintainer doesn't provide patch numbers when versioning.

https://github.com/flaviosilveira/Jquery-Price-Format/releases
